### PR TITLE
Fix flaky test_kick_scan_is_idempotent (drain scan threads)

### DIFF
--- a/backend_service/state.py
+++ b/backend_service/state.py
@@ -196,6 +196,7 @@ class ChaosEngineState:
         self._library_scan_started: bool = False
         self._library_scan_done: threading.Event = threading.Event()
         self._library_scan_generation: int = 0
+        self._library_scan_threads: list[threading.Thread] = []
         self._library_fingerprint: dict[str, float] = {}
         if library_provider is None:
             cached_payload = _load_library_cache(self._library_cache_path)
@@ -312,6 +313,18 @@ class ChaosEngineState:
             daemon=True,
         )
         thread.start()
+        with self._lock:
+            self._library_scan_threads = [
+                t for t in self._library_scan_threads if t.is_alive()
+            ]
+            self._library_scan_threads.append(thread)
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        with self._lock:
+            threads = list(self._library_scan_threads)
+        for t in threads:
+            if t.is_alive():
+                t.join(timeout=timeout)
 
     def _scan_library_into_cache(
         self,

--- a/tests/test_state_async_library.py
+++ b/tests/test_state_async_library.py
@@ -46,8 +46,11 @@ class AsyncLibraryScanTests(unittest.TestCase):
             chat_sessions_path=tmpdir / "chat-sessions.json",
             library_cache_path=tmpdir / "library_cache.json",
         )
+        self.state: ChaosEngineState | None = None
 
     def tearDown(self) -> None:
+        if self.state is not None:
+            self.state.shutdown()
         self.tmp.cleanup()
 
     def test_library_provider_short_circuits_async_scan(self):
@@ -57,10 +60,10 @@ class AsyncLibraryScanTests(unittest.TestCase):
             provider_calls.append(True)
             return [{"name": "fake/model", "path": "/tmp/fake"}]
 
-        state = ChaosEngineState(library_provider=provider, **self.kwargs)
-        self.assertTrue(state._library_scan_done.is_set())
-        self.assertFalse(state._library_scan_started)
-        result = state._library()
+        self.state = ChaosEngineState(library_provider=provider, **self.kwargs)
+        self.assertTrue(self.state._library_scan_done.is_set())
+        self.assertFalse(self.state._library_scan_started)
+        result = self.state._library()
         self.assertEqual(len(result), 1)
         self.assertGreaterEqual(len(provider_calls), 1)
 
@@ -76,14 +79,14 @@ class AsyncLibraryScanTests(unittest.TestCase):
             "backend_service.state._discover_local_models",
             side_effect=slow_scan,
         ):
-            state = ChaosEngineState(**self.kwargs)
+            self.state = ChaosEngineState(**self.kwargs)
             try:
-                self.assertTrue(state._library_scan_done.wait(2.0))
-                workspace = state.workspace()
+                self.assertTrue(self.state._library_scan_done.wait(2.0))
+                workspace = self.state.workspace()
                 self.assertEqual(workspace["libraryStatus"], "ready")
                 self.assertEqual(len(workspace["library"]), 1)
             finally:
-                state._library_scan_done.set()
+                self.state._library_scan_done.set()
 
     def test_kick_scan_is_idempotent(self):
         scan_calls = []
@@ -96,12 +99,12 @@ class AsyncLibraryScanTests(unittest.TestCase):
             "backend_service.state._discover_local_models",
             side_effect=fake_scan,
         ):
-            state = ChaosEngineState(**self.kwargs)
-            self.assertTrue(state._library_scan_done.wait(2.0))
+            self.state = ChaosEngineState(**self.kwargs)
+            self.assertTrue(self.state._library_scan_done.wait(2.0))
             initial_calls = len(scan_calls)
-            state._kick_library_scan()
-            state._kick_library_scan()
-            state._library_scan_done.wait(2.0)
+            self.state._kick_library_scan()
+            self.state._kick_library_scan()
+            self.state._library_scan_done.wait(2.0)
             self.assertGreaterEqual(len(scan_calls), initial_calls)
 
 
@@ -117,22 +120,25 @@ class LazyRuntimeTests(unittest.TestCase):
             chat_sessions_path=tmpdir / "chat-sessions.json",
             library_cache_path=tmpdir / "library_cache.json",
         )
+        self.state: ChaosEngineState | None = None
 
     def tearDown(self) -> None:
+        if self.state is not None:
+            self.state.shutdown()
         self.tmp.cleanup()
 
     def test_runtimes_unconstructed_after_init(self):
-        state = ChaosEngineState(**self.kwargs)
-        self.assertIsNone(state._image_runtime)
-        self.assertIsNone(state._video_runtime)
+        self.state = ChaosEngineState(**self.kwargs)
+        self.assertIsNone(self.state._image_runtime)
+        self.assertIsNone(self.state._video_runtime)
 
     def test_runtime_setter_keeps_test_compat(self):
-        state = ChaosEngineState(**self.kwargs)
+        self.state = ChaosEngineState(**self.kwargs)
         marker = object()
-        state.image_runtime = marker
-        self.assertIs(state.image_runtime, marker)
-        state.video_runtime = marker
-        self.assertIs(state.video_runtime, marker)
+        self.state.image_runtime = marker
+        self.assertIs(self.state.image_runtime, marker)
+        self.state.video_runtime = marker
+        self.assertIs(self.state.video_runtime, marker)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Race in `tests/test_state_async_library.py::AsyncLibraryScanTests::test_kick_scan_is_idempotent` caused intermittent CI failures (`OSError: [Errno 39] Directory not empty`).
- Daemon library-scan threads spawned by `_kick_library_scan` had no handles, so `tearDown`'s `tmp.cleanup()` could rmtree the tmpdir while a thread was still writing `library_cache.json`.
- All four post-merge dependabot CI runs on main (#6, #7, #8, #9) hit the same race — the bumps themselves were fine.

## Fix

- Track spawned scan threads on `ChaosEngineState` and prune dead entries on each kick.
- Add idempotent `ChaosEngineState.shutdown(timeout=5.0)` that joins all alive scan threads.
- Tests assign their constructed state to `self.state` and drain it in `tearDown` before `self.tmp.cleanup()`.

## Verification

- `tests/test_state_async_library.py` now deterministic locally (5/5 runs).
- Full backend `pytest` green on Linux runner via [run 25129383727](https://github.com/cryptopoly/ChaosEngineAI/actions/runs/25129383727) (test job + 3-OS build matrix all ✓).
- `npx tsc --noEmit` clean.
- `npm test` 179/179 pass.

## Test plan

- [x] Target test 5×
- [x] Full backend pytest
- [x] TypeScript typecheck
- [x] Vitest suite
- [x] CI matrix (test + macos-latest + ubuntu-22.04 + windows-latest) on workflow_dispatch