### PR TITLE
Bump v0.7.0-rc.1 (video-gen WIP pre-release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chaosengine-desktop",
-  "version": "0.6.3",
+  "version": "0.7.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chaosengine-desktop",
-      "version": "0.6.3",
+      "version": "0.7.0-rc.1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chaosengine-desktop",
   "private": true,
-  "version": "0.6.31",
+  "version": "0.7.0-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaosengineai"
-version = "0.6.31"
+version = "0.7.0-rc.1"
 dependencies = [
  "flate2",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaosengineai"
-version = "0.6.31"
+version = "0.7.0-rc.1"
 description = "ChaosEngineAI desktop shell for local AI model inference"
 authors = ["OpenAI Codex"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChaosEngineAI",
   "mainBinaryName": "ChaosEngineAI",
-  "version": "0.6.3",
+  "version": "0.7.0-rc.1",
   "identifier": "com.chaosengineai.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary

- Aligns version across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` to `0.7.0-rc.1`.
- Pre-release tag for the in-progress video-gen feature drop.
- Tag `v0.7.0-rc.1` already pushed — `release.yml` is building draft assets in parallel.

## Test plan

- [x] Locks regenerated (`Cargo.lock`, `package-lock.json`)
- [x] CI test job will validate before any merge