### PR TITLE
Release: bundle full runtime + bump v0.7.0-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,13 +222,13 @@ jobs:
         if: matrix.platform == 'windows'
         run: echo "CHAOSENGINE_EMBED_PYTHON_BIN=${{ github.workspace }}\.venv\Scripts\python.exe" >> $env:GITHUB_ENV
 
-      - name: Override bundle command to dev mode staging
+      - name: Override bundle command to release staging
         shell: bash
         run: |
           node -e "
             const fs = require('fs');
             const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
-            conf.build.beforeBundleCommand = 'npm run stage:runtime';
+            conf.build.beforeBundleCommand = 'npm run stage:runtime:release';
             fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
           "
 
@@ -241,6 +241,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CHAOSENGINE_RELEASE_ALLOW_NO_LLAMA: "1"
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           tagName: ${{ inputs.release_tag || github.ref_name }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chaosengine-desktop",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chaosengine-desktop",
-      "version": "0.7.0-rc.1",
+      "version": "0.7.0-rc.2",
       "dependencies": {
         "@tauri-apps/api": "^2.1.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chaosengine-desktop",
   "private": true,
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0-rc.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaosengineai"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "flate2",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaosengineai"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 description = "ChaosEngineAI desktop shell for local AI model inference"
 authors = ["OpenAI Codex"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChaosEngineAI",
   "mainBinaryName": "ChaosEngineAI",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0-rc.2",
   "identifier": "com.chaosengineai.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Why

v0.7.0-rc.1 bundles shipped at 3–6 MB across all OSes — completely non-functional. The `release.yml` workflow was overriding Tauri's `beforeBundleCommand` to `npm run stage:runtime` (development mode), which skips the runtime tar.gz archive and leaves a Tauri shell that expects a live source-workspace at runtime.

## What

- `release.yml`: switch override to `npm run stage:runtime:release` (strict mode) so the embedded Python venv, `llama-server`, ChaosEngine vendor, and optional runtime packages are all bundled into the installer.
- Add `CHAOSENGINE_RELEASE_ALLOW_NO_LLAMA=1` env var as a safety net — if the prebuilt llama.cpp auto-download fails on a runner, the build still succeeds and users can install llama-server via the Setup page on first run.
- Bump version to `0.7.0-rc.2` across `package.json`, `Cargo.toml`, `tauri.conf.json` (+ regenerated locks).

## Impact

Bundles will be substantially larger — macOS includes mlx + mlx-lm + gguf, all platforms include FastAPI + uvicorn + huggingface_hub + a llama-server binary. Heavy diffusion deps (torch, diffusers, mlx-video) remain Setup-page installs to keep the installer reasonable.

## Test plan

- [x] CI test job will validate before merge
- [ ] After merge: tag `v0.7.0-rc.2` and verify `release.yml` produces realistically-sized bundles (expect 100–400 MB depending on platform)