### PR TITLE
Switch macOS Python to python-build-standalone (rc.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,26 @@ jobs:
           restore-keys: cargo-release-${{ matrix.os }}-
 
       - uses: actions/setup-python@v6
+        if: matrix.platform != 'darwin'
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      # macOS uses python-build-standalone (Astral) instead of
+      # actions/setup-python. The setup-python framework is pre-signed
+      # with hardened-runtime flags, and Xcode 16.4's install_name_tool
+      # rejects edits with "link edit information does not fill the
+      # __LINKEDIT segment" — making bundled Python crash at launch on
+      # any user machine without /Library/Frameworks/Python.framework.
+      # python-build-standalone ships relocatable @loader_path / @rpath
+      # references baked in, so no install_name_tool dance is needed.
+      - name: Setup portable Python (macOS)
+        if: matrix.platform == 'darwin'
+        run: |
+          set -euo pipefail
+          PYBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7+20241016-aarch64-apple-darwin-install_only.tar.gz"
+          mkdir -p .python-portable
+          curl -fsSL "$PYBS_URL" | tar -xz -C .python-portable --strip-components=1
+          echo "$(pwd)/.python-portable/bin" >> "$GITHUB_PATH"
 
       - name: Import Apple certificate (macOS)
         if: matrix.platform == 'darwin'
@@ -196,7 +214,7 @@ jobs:
       - name: Create Python venv (macOS)
         if: matrix.platform == 'darwin'
         run: |
-          python -m venv .venv
+          .python-portable/bin/python3 -m venv .venv
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install mlx mlx-lm gguf fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chaosengine-desktop",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chaosengine-desktop",
-      "version": "0.7.0-rc.3",
+      "version": "0.7.0-rc.4",
       "dependencies": {
         "@tauri-apps/api": "^2.1.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chaosengine-desktop",
   "private": true,
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/stage-runtime.mjs
+++ b/scripts/stage-runtime.mjs
@@ -1132,6 +1132,7 @@ function relocateDarwinPythonReferences(rootPath) {
 
   let rewrites = 0;
   let touchedFiles = 0;
+  let filesWithMatches = 0;
   let firstFailureLogged = false;
   for (const target of machoTargets) {
     let deps;
@@ -1142,6 +1143,7 @@ function relocateDarwinPythonReferences(rootPath) {
     }
     const matches = Array.from(deps.matchAll(frameworkRefPattern));
     if (matches.length === 0) continue;
+    filesWithMatches++;
 
     // Dedupe on the full reference so we only run install_name_tool once
     // per unique path per Mach-O.
@@ -1196,13 +1198,20 @@ function relocateDarwinPythonReferences(rootPath) {
     console.warn(`[stage-runtime] warning: ad-hoc re-sign failed on ${pythonDylibPath}: ${err.message}`);
   }
 
+  if (filesWithMatches === 0) {
+    console.log(
+      `[stage-runtime] no Python framework relocation needed across ${machoTargets.length} Mach-O files (already portable — likely python-build-standalone)`,
+    );
+    return;
+  }
+
   console.log(
-    `[stage-runtime] relocated Python framework references (${rewrites} rewrites across ${touchedFiles}/${machoTargets.length} Mach-O files)`,
+    `[stage-runtime] relocated Python framework references (${rewrites} rewrites across ${touchedFiles}/${filesWithMatches} affected Mach-O files; ${machoTargets.length} scanned)`,
   );
 
-  if (strict && touchedFiles < machoTargets.length / 2) {
+  if (strict && touchedFiles < filesWithMatches) {
     throw new Error(
-      `Python framework relocation rewrote only ${touchedFiles}/${machoTargets.length} Mach-O files. ` +
+      `Python framework relocation rewrote only ${touchedFiles}/${filesWithMatches} affected Mach-O files. ` +
       `The bundle will crash on user machines without /Library/Frameworks/Python.framework installed. ` +
       `Check the install_name_tool warning above for the underlying error.`,
     );

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaosengineai"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 dependencies = [
  "flate2",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaosengineai"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 description = "ChaosEngineAI desktop shell for local AI model inference"
 authors = ["OpenAI Codex"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChaosEngineAI",
   "mainBinaryName": "ChaosEngineAI",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "identifier": "com.chaosengineai.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Why

`v0.7.0-rc.3`'s strict guard correctly caught the bundle bug instead of shipping a broken installer. CI surfaced the real `install_name_tool` error:

\`\`\`
fatal error: file not in an order that can be processed
(link edit information does not fill the __LINKEDIT segment)
\`\`\`

`actions/setup-python` ships a Python framework pre-signed with hardened-runtime flags. Xcode 16.4's `install_name_tool` refuses to edit the resulting binaries because `codesign --remove-signature` leaves trailing padding in the `__LINKEDIT` segment. Relocation pass rewrote only 1/124 files; strict guard hard-failed the build (good).

## What

Replace the macOS Python source with [python-build-standalone (Astral)](https://github.com/astral-sh/python-build-standalone) — a relocatable Python distribution specifically designed for embedding. Binaries ship with `@loader_path` / `@rpath` references baked in, so no `install_name_tool` dance is required.

- `release.yml`:
  - Gate `actions/setup-python@v6` to non-darwin matrices
  - On darwin, download `cpython-3.12.7+20241016-aarch64-apple-darwin-install_only.tar.gz` and prepend its `bin/` to PATH
  - `Create Python venv (macOS)` now uses the portable Python explicitly
- `scripts/stage-runtime.mjs`: track files-with-framework-matches separately from total Mach-O scanned. If no files reference `/Library/Frameworks/Python.framework/...` (python-build-standalone case), log `no relocation needed` and return cleanly. Strict guard fires only on unrewritten files that DID match — no spurious failures on already-portable Python.

## Impact

- macOS bundles will use python-build-standalone Python (relocatable by design, no signature dance)
- Linux and Windows builds untouched
- Same bundle structure for the Tauri shell — just a swap of upstream Python source

## Test plan

- [x] CI test job (Linux) before merge
- [ ] After merge: tag `v0.7.0-rc.4` and verify the macOS dmg launches without the `Library not loaded` crash
- [ ] Backend reaches Studio (no "Still loading" hang)
- [ ] Smoke-test on Linux + Windows that the python-build-standalone branch doesn't break their setup