### PR TITLE
Updater manifest tolerates missing signatures

### DIFF
--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -87,8 +87,22 @@ async function main() {
     missing.push(`${windowsAssetName} / ${windowsSigName}`);
   }
 
+  if (Object.keys(platforms).length === 0) {
+    // tauri.conf.json has bundle.createUpdaterArtifacts=false (or signing
+    // failed silently across every platform). Without any signatures we
+    // can't publish a useful updater manifest, but this isn't a release
+    // failure — the bundles themselves are still valid installers.
+    console.log(
+      `No updater signatures attached to this release (${missing.join(", ")}). ` +
+      `Skipping latest.json generation.`,
+    );
+    return;
+  }
   if (missing.length) {
-    throw new Error(`Cannot generate updater manifest; missing updater assets: ${missing.join(", ")}`);
+    console.log(
+      `Updater manifest will cover only the platforms with attached signatures. ` +
+      `Skipping: ${missing.join(", ")}.`,
+    );
   }
 
   const manifest = {


### PR DESCRIPTION
## Why

\`v0.7.0-rc.4\` produced **working bundles for all three OSes** — first time this RC line is launchable end-to-end. But the \`publish-manifest\` job failed:

\`\`\`
Cannot generate updater manifest; missing updater assets: macOS updater bundle/signature, ...
\`\`\`

Cause: tauri.conf.json now has \`bundle.createUpdaterArtifacts=false\` (your edit), so no \`.sig\` files are produced. \`generate-updater-manifest.mjs\` threw because it expected them.

## What

Make \`generate-updater-manifest.mjs\` tolerant:
- If **zero** platforms have signatures → log and return cleanly (no \`latest.json\` published; bundles themselves are still valid installers)
- If **some** platforms are missing → generate manifest covering the platforms that do have sigs; log the skipped ones

## Impact

- Re-running \`publish-manifest\` on the rc.4 release run will now succeed (skipping manifest generation)
- Downloads of the rc.4 bundles unaffected
- If updater artifacts are re-enabled later, the manifest job will pick up whichever platforms have sigs without code change

## Test plan

- [x] Linux test job before merge
- [ ] After merge: rerun the failed \`publish-manifest\` job on the rc.4 [release run](https://github.com/cryptopoly/ChaosEngineAI/actions/runs/25133977724) and confirm it logs "skipping latest.json generation" + exits 0