### PR TITLE
Namespace persistent extras dir by Python ABI tag (rc.5)

### DIFF
--- a/backend_service/routes/setup.py
+++ b/backend_service/routes/setup.py
@@ -704,11 +704,14 @@ def _extras_site_packages() -> Path | None:
     """Resolve the user-persistent extras site-packages dir.
 
     The Tauri shell sets ``CHAOSENGINE_EXTRAS_SITE_PACKAGES`` to a path
-    like ``%LOCALAPPDATA%\\ChaosEngineAI\\extras\\site-packages`` (Windows)
-    or ``~/Library/Application Support/ChaosEngineAI/extras/site-packages``
-    (macOS). When the backend runs outside Tauri (``python -m backend_service``
-    for dev / tests) we fall back to a predictable default so pip --target
-    still has somewhere to write.
+    namespaced by Python ``major.minor`` (e.g.
+    ``~/Library/Application Support/ChaosEngineAI/extras/cp312/site-packages``)
+    so wheels compiled against one Python ABI can't shadow a different
+    interpreter on the next launch — that bit users in v0.7.0-rc.4 when
+    a switch from cp311 to cp312 left a dead pydantic_core wheel in
+    place. When the backend runs outside Tauri (``python -m backend_service``
+    for dev / tests) we fall back to a predictable default that uses the
+    *current* interpreter's tag.
     """
     env_path = os.environ.get("CHAOSENGINE_EXTRAS_SITE_PACKAGES")
     if env_path:
@@ -720,7 +723,8 @@ def _extras_site_packages() -> Path | None:
         base = home / "Library" / "Application Support"
     else:
         base = Path(os.environ.get("XDG_DATA_HOME") or home / ".local" / "share")
-    return base / "ChaosEngineAI" / "extras" / "site-packages"
+    tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    return base / "ChaosEngineAI" / "extras" / tag / "site-packages"
 
 
 def _cleanup_mlx_video_shadow_metadata(extras_dir: Path) -> list[str]:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chaosengine-desktop",
-  "version": "0.7.0-rc.4",
+  "version": "0.7.0-rc.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chaosengine-desktop",
-      "version": "0.7.0-rc.4",
+      "version": "0.7.0-rc.5",
       "dependencies": {
         "@tauri-apps/api": "^2.1.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chaosengine-desktop",
   "private": true,
-  "version": "0.7.0-rc.4",
+  "version": "0.7.0-rc.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaosengineai"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "flate2",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaosengineai"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 description = "ChaosEngineAI desktop shell for local AI model inference"
 authors = ["OpenAI Codex"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,9 @@ struct EmbeddedRuntimeManifest {
     llama_server_turbo: Option<String>,
     llama_cli: Option<String>,
     sd_cpp: Option<String>,
+    // ``"3.12"`` etc. — used to namespace the persistent extras dir so
+    // wheels compiled for Python X.Y don't get loaded by a different X.Z.
+    python_version: Option<String>,
 }
 
 #[derive(Clone, Deserialize)]
@@ -99,6 +102,7 @@ struct EmbeddedRuntime {
     llama_server_turbo: Option<PathBuf>,
     llama_cli: Option<PathBuf>,
     sd_cpp: Option<PathBuf>,
+    python_version: Option<String>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -322,8 +326,15 @@ impl BackendManager {
             // backend whether we're in embedded-runtime or dev-source mode.
             // The install-gpu-bundle endpoint always writes to this path so
             // users can switch between dev builds / packaged builds without
-            // redownloading 2 GB of CUDA torch every time.
-            if let Some(extras) = ensure_extras_site_packages() {
+            // redownloading 2 GB of CUDA torch every time. The path is
+            // namespaced by Python ``major.minor`` so cp311 wheels can't
+            // shadow a cp312 runtime (or vice versa).
+            let python_version_hint = embedded_runtime
+                .as_ref()
+                .and_then(|runtime| runtime.python_version.as_deref());
+            if let Some(extras) =
+                ensure_extras_site_packages_for_python(&python_executable, python_version_hint)
+            {
                 command.env("CHAOSENGINE_EXTRAS_SITE_PACKAGES", extras.as_os_str());
             }
 
@@ -365,7 +376,10 @@ impl BackendManager {
                 // apply_embedded_runtime_env already does this for the
                 // embedded path; this is the matching source-workspace
                 // branch. No-op if extras doesn't exist yet.
-                if let Some(extras) = chaosengine_extras_site_packages().filter(|p| p.is_dir()) {
+                if let Some(extras) =
+                    chaosengine_extras_site_packages_for_python(&python_executable, python_version_hint)
+                        .filter(|p| p.is_dir())
+                {
                     if let Some(python_path) = join_paths(&[extras]) {
                         command.env("PYTHONPATH", python_path);
                     }
@@ -630,8 +644,11 @@ fn apply_embedded_runtime_env(command: &mut Command, runtime: &EmbeddedRuntime) 
     // on each launch, but never touches the extras tree.
     // (CHAOSENGINE_EXTRAS_SITE_PACKAGES is already set by the caller so
     // the backend can target it for pip --target installs.)
-    let extras_dir = chaosengine_extras_site_packages()
-        .filter(|path| path.is_dir());
+    let extras_dir = chaosengine_extras_site_packages_for_python(
+        &runtime.python_binary,
+        runtime.python_version.as_deref(),
+    )
+    .filter(|path| path.is_dir());
     let mut python_path_entries: Vec<PathBuf> = Vec::with_capacity(runtime.python_path.len() + 1);
     if let Some(extras) = extras_dir.as_ref() {
         python_path_entries.push(extras.clone());
@@ -660,15 +677,20 @@ fn apply_embedded_runtime_env(command: &mut Command, runtime: &EmbeddedRuntime) 
 /// Persistent user-local site-packages directory. Survives app updates,
 /// so CUDA torch / diffusers installed once stays installed forever.
 ///
-/// - Windows: ``%LOCALAPPDATA%\ChaosEngineAI\extras\site-packages``
-/// - macOS:   ``~/Library/Application Support/ChaosEngineAI/extras/site-packages``
-/// - Linux:   ``$XDG_DATA_HOME/ChaosEngineAI/extras/site-packages`` (falls
-///            back to ``~/.local/share/ChaosEngineAI/extras/site-packages``)
+/// Path is namespaced by Python ``major.minor`` (``cp312``, ``cp311``)
+/// because compiled C-extensions are ABI-incompatible across Python
+/// versions. A pydantic_core wheel built for cp311 will fail to import
+/// on cp312 and stall app launch — see the rc.4 boot crash that drove
+/// this scheme.
+///
+/// - Windows: ``%LOCALAPPDATA%\ChaosEngineAI\extras\cp{tag}\site-packages``
+/// - macOS:   ``~/Library/Application Support/ChaosEngineAI/extras/cp{tag}/site-packages``
+/// - Linux:   ``$XDG_DATA_HOME/ChaosEngineAI/extras/cp{tag}/site-packages``
+///            (fallback ``~/.local/share/...``)
 ///
 /// Returns ``None`` if we can't resolve a home directory at all (headless
-/// environments). Callers treat that as "no extras available" and proceed
-/// with whatever's bundled.
-fn chaosengine_extras_site_packages() -> Option<PathBuf> {
+/// environments). Callers treat that as "no extras available".
+fn chaosengine_extras_root() -> Option<PathBuf> {
     let base = if cfg!(windows) {
         env::var_os("LOCALAPPDATA")
             .map(PathBuf::from)
@@ -681,11 +703,47 @@ fn chaosengine_extras_site_packages() -> Option<PathBuf> {
             .map(PathBuf::from)
             .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".local").join("share")))
     }?;
-    Some(base.join("ChaosEngineAI").join("extras").join("site-packages"))
+    Some(base.join("ChaosEngineAI").join("extras"))
 }
 
-fn ensure_extras_site_packages() -> Option<PathBuf> {
-    let path = chaosengine_extras_site_packages()?;
+fn python_version_tag(raw: &str) -> Option<String> {
+    // Accept "3.12", "3.12.7", "cpython-3.12.7+...", etc. Extract major.minor.
+    let mut parts = raw.split(|c: char| !c.is_ascii_digit() && c != '.');
+    let candidate = parts.find(|chunk| chunk.contains('.'))?;
+    let mut iter = candidate.split('.');
+    let major = iter.next()?.parse::<u32>().ok()?;
+    let minor = iter.next()?.parse::<u32>().ok()?;
+    Some(format!("cp{major}{minor}"))
+}
+
+fn detect_python_version_tag(python: &Path) -> Option<String> {
+    let output = Command::new(python)
+        .args([
+            "-c",
+            "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    python_version_tag(raw.trim())
+}
+
+fn chaosengine_extras_site_packages_for(tag: &str) -> Option<PathBuf> {
+    Some(chaosengine_extras_root()?.join(tag).join("site-packages"))
+}
+
+fn chaosengine_extras_site_packages_for_python(python: &Path, hint: Option<&str>) -> Option<PathBuf> {
+    let tag = hint
+        .and_then(python_version_tag)
+        .or_else(|| detect_python_version_tag(python))?;
+    chaosengine_extras_site_packages_for(&tag)
+}
+
+fn ensure_extras_site_packages_for_python(python: &Path, hint: Option<&str>) -> Option<PathBuf> {
+    let path = chaosengine_extras_site_packages_for_python(python, hint)?;
     match fs::create_dir_all(&path) {
         Ok(_) => Some(path),
         Err(error) => {
@@ -889,6 +947,7 @@ fn resolve_embedded_runtime(app: &AppHandle) -> Option<EmbeddedRuntime> {
             .map(|entry| extracted_root.join(entry)),
         llama_cli: manifest.llama_cli.as_ref().map(|entry| extracted_root.join(entry)),
         sd_cpp: manifest.sd_cpp.as_ref().map(|entry| extracted_root.join(entry)),
+        python_version: manifest.python_version.clone(),
     };
 
     if runtime.backend_root.exists() && runtime.python_binary.exists() && runtime.python_home.exists() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChaosEngineAI",
   "mainBinaryName": "ChaosEngineAI",
-  "version": "0.7.0-rc.4",
+  "version": "0.7.0-rc.5",
   "identifier": "com.chaosengineai.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Why

\`v0.7.0-rc.4\` macOS users with an existing extras tree crashed at boot:

\`\`\`
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
\`\`\`

The persistent extras dir (\`~/Library/Application Support/ChaosEngineAI/extras/site-packages\`) is intentionally on \`PYTHONPATH\` ahead of the bundled venv so user-installed CUDA torch wins over anything shipped with the app. After switching the bundled Python to **python-build-standalone 3.12.7**, an existing extras tree compiled for cp311 took priority and dyld couldn't find the cp312 native extension. Same hazard exists in reverse if a future build downgrades the embedded Python.

## What

Namespace extras by Python \`major.minor\`:

\`\`\`
~/Library/Application Support/ChaosEngineAI/extras/cp312/site-packages/
~/Library/Application Support/ChaosEngineAI/extras/cp311/site-packages/
\`\`\`

- **\`src-tauri/src/lib.rs\`**:
  - Add \`python_version\` field to \`EmbeddedRuntimeManifest\` + \`EmbeddedRuntime\`
  - New \`chaosengine_extras_root()\` returns the un-namespaced base
  - New \`chaosengine_extras_site_packages_for_python(python, hint)\` appends \`cp{major}{minor}/site-packages\`, deriving the tag from the manifest hint or falling back to invoking the Python binary directly
  - \`apply_embedded_runtime_env\`, the embedded-mode env setup, and the source-workspace branch all flow through the new helper
- **\`backend_service/routes/setup.py\`**: \`_extras_site_packages()\` fallback (when Tauri hasn't set the env var) uses the current interpreter's tag

## Migration

Pre-existing extras at the legacy unversioned path are **silently ignored** — they no longer match the active interpreter and never get loaded onto \`sys.path\` again, so they can't shadow a fresh runtime. Users can delete the legacy tree at their leisure; \`install-gpu-bundle\` will populate the new tagged path on next use.

## Test plan

- [x] \`pytest tests/test_setup_routes.py\` (47 tests passing locally)
- [x] \`cargo check\` clean
- [x] CI test job (Linux) before merge
- [ ] After merge: tag \`v0.7.0-rc.5\` and verify the macOS dmg launches even with a pre-existing legacy extras tree