### PR TITLE
Pin imageDiscoverMemoryEstimate tests to Mac host

### DIFF
--- a/src/utils/__tests__/images.test.ts
+++ b/src/utils/__tests__/images.test.ts
@@ -1,8 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ImageModelVariant } from "../../types";
 import { assessImageGenerationSafety, imageDiscoverMemoryEstimate } from "../images";
 import { compareDiscoverVariants } from "../discoverSort";
+
+// imageDiscoverMemoryEstimate calls assessImageGenerationSafety with
+// device=null, which falls through to inferDeviceFromHostPlatform().
+// That helper reads navigator.userAgentData.platform and returns
+// "mps" on macOS, "cuda" elsewhere. The expected values in the
+// imageDiscoverMemoryEstimate describe block below were calibrated for
+// the MPS path (FLUX text encoders, MPS runtime overhead, MPS-specific
+// runtimeFootprint overrides), so we pin the host to macOS for the
+// duration of those tests. CI runs on Linux runners where the
+// inference would otherwise return "cuda" and produce different numbers.
+function pinHostPlatformToMac(): void {
+  vi.stubGlobal("navigator", {
+    userAgentData: { platform: "macOS" },
+    platform: "MacIntel",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+  });
+}
 
 describe("assessImageGenerationSafety()", () => {
   it("does not block standard FLUX 1024px generation on a 64 GB MPS Mac", () => {
@@ -127,6 +144,13 @@ describe("assessImageGenerationSafety()", () => {
 });
 
 describe("imageDiscoverMemoryEstimate()", () => {
+  beforeEach(() => {
+    pinHostPlatformToMac();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   const baseVariant: ImageModelVariant = {
     id: "black-forest-labs/FLUX.1-schnell",
     familyId: "flux-fast",


### PR DESCRIPTION
## Summary

Three tests in \`src/utils/__tests__/images.test.ts\` have been failing on CI since 2026-04-29 (PR #20 video-gen merge). They pass locally on Mac developer boxes but fail on \`ubuntu-latest\` because:

- \`imageDiscoverMemoryEstimate(variant)\` calls \`assessImageGenerationSafety\` with \`device: null\`.
- That falls through to \`inferDeviceFromHostPlatform()\` (in \`src/utils/videos.ts\`) which inspects \`navigator.userAgentData.platform\` and returns \`"mps"\` on macOS, \`"cuda"\` everywhere else.
- The expected values in the three failing tests were calibrated against the MPS path (FLUX text encoders, MPS runtime overhead, MPS-specific \`runtimeFootprint\` overrides).

CI failure summary on commit 92e6ca9:

\`\`\`
modelFootprintGb 7.5  -> 4.5   (no MPS multiplier)
modelFootprintGb 41.3 -> 18.3  (no MPS GGUF overhead)
modelFootprintGb 20   -> 16    (skips runtimeFootprintMpsGb override)
\`\`\`

## Fix

Stub \`navigator\` + \`navigator.userAgentData.platform\` to \`"macOS"\` inside the \`imageDiscoverMemoryEstimate\` describe block via \`beforeEach\` + \`vi.stubGlobal\`. Restore globals after each test via \`afterEach\` + \`vi.unstubAllGlobals\`.

The \`assessImageGenerationSafety\` describe block above is untouched — it always passes an explicit \`device\`, so host-inference never fires there.

## Test plan

- [x] \`npm test\` locally on macOS — 207/207 pass
- [ ] CI on Linux — confirm 207/207 once this PR merges

## Why now

Surfaced on the v0.7.2 smoke-test follow-up merges (#21, #22, #23). The bug pre-dates all three of those PRs but was on the list of CI failures inherited from PR #20.