### PR TITLE
Allow None vram_total_gb in test_gpu.py snapshot test

### DIFF
--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -29,11 +29,15 @@ class GPUMonitorSnapshotTests(unittest.TestCase):
         snapshot = monitor.snapshot()
         self.assertIsInstance(snapshot["gpu_name"], str)
 
-    def test_snapshot_vram_values_are_numeric(self):
+    def test_snapshot_vram_values_are_numeric_or_none(self):
+        # ``None`` is a valid response when neither torch.cuda nor
+        # nvidia-smi can answer — we deliberately don't fall back to
+        # system RAM via psutil any more (would mislead the safety
+        # estimator). Numeric otherwise.
         monitor = GPUMonitor()
         snapshot = monitor.snapshot()
-        self.assertIsInstance(snapshot["vram_total_gb"], (int, float))
-        self.assertIsInstance(snapshot["vram_used_gb"], (int, float))
+        self.assertIsInstance(snapshot["vram_total_gb"], (int, float, type(None)))
+        self.assertIsInstance(snapshot["vram_used_gb"], (int, float, type(None)))
 
 
 class GPUMonitorNvidiaTests(unittest.TestCase):


### PR DESCRIPTION
Trivial CI test fix. PR #22 changed _snapshot_nvidia to return vram_total_gb=None when neither torch.cuda nor nvidia-smi can answer (the no-system-RAM-fallback contract), but the pre-existing test_snapshot_vram_values_are_numeric still required (int, float). Linux CI runners hit the None branch and fail.

Fix landed twice on side branches (3b147a9 in PR #24, 59cd81c in PR #25) but both pushes happened after the parent PR had already merged, so they orphaned. Landing it directly here.

Loosens the type check to (int, float, type(None)) and renames the test to ..._numeric_or_none.

```
.venv/bin/python -m pytest tests/test_gpu.py -q
.................s                                                       [100%]
```