### PR TITLE
chore: v0.9.0 release fixes — version bump, submodule cleanup, Windows build fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'linux'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/ChaosEngine"]
-	path = vendor/ChaosEngine
-	url = https://github.com/Cryptopoly/ChaosEngine

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chaosengine-desktop",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaosengineai"
-version = "0.8.0"
+version = "0.9.0"
 description = "ChaosEngineAI desktop shell for local AI model inference"
 authors = ["OpenAI Codex"]
 edition = "2021"

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -13,6 +13,8 @@ use std::env;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -292,7 +294,7 @@ impl BackendManager {
                     // cleanup_orphaned_backends sweep on next launch.
                     #[cfg(windows)]
                     {
-                        let _ = windows_job::assign_to_kill_on_close_job(&child);
+                        let _ = crate::windows_job::assign_to_kill_on_close_job(&child);
                     }
 
                     let lease = ManagedBackendLease {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ChaosEngineAI",
   "mainBinaryName": "ChaosEngineAI",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.chaosengineai.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Three commits to bring staging in line with main for the v0.9.0 release:

- `chore: bump version to 0.9.0` — tauri.conf.json, package.json, Cargo.toml
- `fix: remove stale ChaosEngine submodule + drop submodules flag from release workflow` — FU-030 missed cleaning up .gitmodules; caused CI checkout to fail
- `fix: add Windows CommandExt import + fix windows_job crate path in backend.rs` — missing trait import caused Windows Rust compile failure in release workflow