### PR TITLE
fix: babel bundling + updater artifacts + i18n middleware fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,7 @@ jobs:
             const fs = require('fs');
             const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
             conf.build.beforeBundleCommand = 'npm run stage:runtime:release';
+            conf.bundle.createUpdaterArtifacts = true;
             fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
           "
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,21 +214,21 @@ jobs:
         run: |
           .python-portable/bin/python3 -m venv .venv
           .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install mlx mlx-lm gguf fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub
+          .venv/bin/pip install mlx mlx-lm gguf fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub babel
 
       - name: Create Python venv (Linux)
         if: matrix.platform == 'linux'
         run: |
           python -m venv .venv
           .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub
+          .venv/bin/pip install fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub babel
 
       - name: Create Python venv (Windows)
         if: matrix.platform == 'windows'
         run: |
           python -m venv .venv
           .venv\Scripts\pip install --upgrade pip
-          .venv\Scripts\pip install fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub
+          .venv\Scripts\pip install fastapi psutil uvicorn "pypdf>=6.10.2" python-multipart huggingface_hub babel
 
       - name: Set Python embed path (Unix)
         if: matrix.platform != 'windows'

--- a/backend_service/i18n.py
+++ b/backend_service/i18n.py
@@ -133,12 +133,19 @@ def _load_translations(locale: str):
     fills" workflow without breaking user-facing surfaces."""
     # Lazy import: keeps Babel out of the import chain for callers
     # that never localize (mlx_worker, vllm, ddtree, etc.).
-    from babel.support import NullTranslations, Translations
+    # Fallback to stdlib gettext when babel is not bundled (e.g. fresh
+    # installs before the extras bundle includes babel).
+    try:
+        from babel.support import NullTranslations, Translations as _Translations
+        _babel_available = True
+    except ImportError:
+        from gettext import NullTranslations  # type: ignore[assignment]
+        _babel_available = False
 
-    if locale == DEFAULT_LOCALE:
+    if locale == DEFAULT_LOCALE or not _babel_available:
         return NullTranslations()
     try:
-        return Translations.load(str(LOCALE_DIR), [locale, DEFAULT_LOCALE], DOMAIN)
+        return _Translations.load(str(LOCALE_DIR), [locale, DEFAULT_LOCALE], DOMAIN)
     except Exception:
         return NullTranslations()
 

--- a/scripts/stage-runtime.mjs
+++ b/scripts/stage-runtime.mjs
@@ -190,7 +190,7 @@ function validateBundledPythonPackages(pythonBinary) {
   const script = [
     "import importlib.util, json",
     "requirements = {",
-    "  'desktop': [('fastapi', 'fastapi'), ('huggingface_hub', 'huggingface_hub'), ('psutil', 'psutil'), ('pypdf', 'pypdf'), ('uvicorn', 'uvicorn')],",
+    "  'desktop': [('fastapi', 'fastapi'), ('huggingface_hub', 'huggingface_hub'), ('psutil', 'psutil'), ('pypdf', 'pypdf'), ('uvicorn', 'uvicorn'), ('babel', 'babel')],",
     "  'images': [('accelerate', 'accelerate'), ('diffusers', 'diffusers'), ('huggingface_hub', 'huggingface_hub'), ('PIL', 'pillow'), ('safetensors', 'safetensors'), ('torch', 'torch')],",
     "  'inference': [('dflash_mlx', 'dflash-mlx'), ('turboquant', 'turboquant'), ('turboquant_mlx', 'turboquant-mlx-full')],",
     "}",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaosengineai"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
  "fluent-bundle",


### PR DESCRIPTION
Three commits missing from main since the last merge:

- `fix: enable createUpdaterArtifacts in CI release workflow` — .sig files weren't being generated; latest.json was skipped
- `fix: bundle babel in release + fallback import when missing` — babel missing from CI pip install caused every request to crash in the i18n middleware (ModuleNotFoundError), leaving the app stuck on "Still loading" forever
- `Update Cargo.lock` — dependency lockfile update