### PR TITLE
chore(deps): bump mkdocs-material from >=9.5 to >=9.7.6

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,5 +3,5 @@
 # Build the site with: .venv/bin/mkdocs build --strict
 
 mkdocs>=1.6.1
-mkdocs-material>=9.5
+mkdocs-material>=9.7.6
 pymdown-extensions>=10.21.3


### PR DESCRIPTION
Applies dependabot PR #64 change on top of staging (after #60 and #62 already merged, causing a conflict on the original branch). Minimal change: mkdocs-material floor 9.5 → 9.7.6.